### PR TITLE
feat: improve Slack webhook signature verification

### DIFF
--- a/src/webhooks/dispatcher.ts
+++ b/src/webhooks/dispatcher.ts
@@ -92,12 +92,15 @@ export class WebhookDispatcher {
       // Verify signature
       const signature = this.getSignatureFromHeaders(source, request);
       const secret = webhookConfig.sources[source].secret;
-      
+      const timestamp =
+        source === 'slack' ? request.headers.get('X-Slack-Request-Timestamp') : null;
+
       const isValidSignature = await this.security.verifySignature(
         source,
         payloadText,
         signature,
-        secret
+        secret,
+        timestamp
       );
 
       if (!isValidSignature) {

--- a/src/webhooks/webhooks.test.ts
+++ b/src/webhooks/webhooks.test.ts
@@ -110,6 +110,87 @@ describe('Webhook Integration Tests', () => {
       expect(isValid).toBe(false);
     });
 
+    it('should verify Slack signature correctly', async () => {
+      const payload = '{"type":"event_callback"}';
+      const secret = 'my-secret';
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+
+      const baseString = `v0:${timestamp}:${payload}`;
+      const encoder = new TextEncoder();
+      const key = await crypto.subtle.importKey(
+        'raw',
+        encoder.encode(secret),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign']
+      );
+      const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(baseString));
+      const expectedSig =
+        'v0=' +
+        Array.from(new Uint8Array(signature))
+          .map(b => b.toString(16).padStart(2, '0'))
+          .join('');
+
+      const isValid = await security.verifySignature(
+        'slack',
+        payload,
+        expectedSig,
+        secret,
+        timestamp
+      );
+
+      expect(isValid).toBe(true);
+    });
+
+    it('should reject invalid Slack signatures', async () => {
+      const payload = '{"type":"event_callback"}';
+      const secret = 'my-secret';
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const invalidSignature = 'v0=invalid';
+
+      const isValid = await security.verifySignature(
+        'slack',
+        payload,
+        invalidSignature,
+        secret,
+        timestamp
+      );
+
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject Slack signatures with old timestamp', async () => {
+      const payload = '{"type":"event_callback"}';
+      const secret = 'my-secret';
+      const oldTimestamp = (Math.floor(Date.now() / 1000) - 60 * 10).toString(); // 10 minutes ago
+
+      const baseString = `v0:${oldTimestamp}:${payload}`;
+      const encoder = new TextEncoder();
+      const key = await crypto.subtle.importKey(
+        'raw',
+        encoder.encode(secret),
+        { name: 'HMAC', hash: 'SHA-256' },
+        false,
+        ['sign']
+      );
+      const signature = await crypto.subtle.sign('HMAC', key, encoder.encode(baseString));
+      const expectedSig =
+        'v0=' +
+        Array.from(new Uint8Array(signature))
+          .map(b => b.toString(16).padStart(2, '0'))
+          .join('');
+
+      const isValid = await security.verifySignature(
+        'slack',
+        payload,
+        expectedSig,
+        secret,
+        oldTimestamp
+      );
+
+      expect(isValid).toBe(false);
+    });
+
     it('should validate payload structures correctly', async () => {
       const validGitHubPayload = {
         action: 'opened',


### PR DESCRIPTION
## Summary
- compute Slack signatures using `v0:{timestamp}:{payload}` and compare the full `X-Slack-Signature`
- reject Slack webhook requests with stale timestamps
- test Slack signature verification for valid, invalid, and replayed requests

## Testing
- `npm test` *(fails: Integration Tests > Bidirectional Sync Flow > should handle duplicate prevention, Integration Tests > Conflict Detection and Resolution > should detect and auto-resolve conflicts, Integration Tests > Conflict Detection and Resolution > should store unresolved conflicts when manual resolution required, Integration Tests > Bulk Operations > should handle bulk sync of multiple tasks, Integration Tests > Idempotency > should return cached response for duplicate requests, Integration Tests > Metrics Tracking > should track sync metrics)*

------
https://chatgpt.com/codex/tasks/task_e_689f741e6ef483278210357191306662