### PR TITLE
Handle Todoist 204 responses without JSON parsing

### DIFF
--- a/src/todoist.test.ts
+++ b/src/todoist.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TodoistClient } from './todoist';
+import { Env, TodoistTask } from './types';
+
+describe('TodoistClient', () => {
+  let env: Env;
+
+  beforeEach(() => {
+    env = {
+      TODOIST_API_URL: 'https://api.todoist.com',
+      TODOIST_API_TOKEN: 'test-token',
+      SYNC_METADATA: {} as any
+    } as Env;
+    vi.resetAllMocks();
+  });
+
+  describe('closeTask', () => {
+    it('should handle 204 response without throwing', async () => {
+      const task: TodoistTask = {
+        id: '123',
+        project_id: '1',
+        content: 'Test task',
+        description: '',
+        priority: 1,
+        labels: [],
+        created_at: new Date().toISOString(),
+        creator_id: 'user',
+        comment_count: 0,
+        is_completed: false,
+        url: 'https://todoist.com'
+      };
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify(task), { status: 200 })
+        )
+        .mockResolvedValueOnce(new Response(null, { status: 204 }));
+      const originalFetch = global.fetch;
+      // @ts-ignore
+      global.fetch = fetchMock;
+
+      const client = new TodoistClient(env);
+      await expect(client.closeTask('123')).resolves.toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      // Restore original fetch
+      global.fetch = originalFetch;
+    });
+  });
+});

--- a/src/todoist.ts
+++ b/src/todoist.ts
@@ -51,7 +51,12 @@ export class TodoistClient {
         throw new Error(`Todoist API error: ${response.status} ${response.statusText}`);
       }
 
-      return response.json();
+      if (response.status === 204) {
+        // No content to parse for successful requests
+        return undefined as unknown as T;
+      }
+
+      return (await response.json()) as T;
     } catch (error) {
       // Network errors - retry with backoff
       if (retryCount < maxRetries) {


### PR DESCRIPTION
## Summary
- Avoid JSON parsing for 204 responses in Todoist client request helper
- Cover 204-response behavior with new closeTask unit test

## Testing
- `npm test` *(fails: fetch errors and test timeouts in integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f7420fc308327bff44ea04905ae76