### PR TITLE
Reduce KV operations and cached status in worker

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface Env {
   TODOIST_API_URL: string;
   SYNC_METADATA: KVNamespace;
   REPAIR_AUTH_TOKEN?: string;
+  ENABLE_WEBHOOK_LOGS?: string;
 }
 
 export interface ScheduledEvent {
@@ -176,5 +177,10 @@ export interface BatchSyncState {
   };
   thingsIndex: {
     [thingsId: string]: string; // Points to fingerprint
+  };
+  stats?: {
+    mappingCount: number;
+    migratedLegacyMappings?: number;
+    pendingLegacyMigration?: number;
   };
 }

--- a/src/webhooks/dispatcher.ts
+++ b/src/webhooks/dispatcher.ts
@@ -228,11 +228,13 @@ export class WebhookDispatcher {
         status: 'pending'
       };
 
-      await this.env.SYNC_METADATA.put(
-        `sync-request:${syncRequest.id}`, 
-        JSON.stringify(syncRequest),
-        { expirationTtl: 600 } // Expire in 10 minutes
-      );
+      if (this.env.ENABLE_WEBHOOK_LOGS === 'true') {
+        await this.env.SYNC_METADATA.put(
+          `sync-request:${syncRequest.id}`,
+          JSON.stringify(syncRequest),
+          { expirationTtl: 300 }
+        );
+      }
 
       return true;
     } catch (error) {

--- a/src/webhooks/handlers.ts
+++ b/src/webhooks/handlers.ts
@@ -327,7 +327,9 @@ export class WebhookHandlers {
           todoistId,
           status: 'pending'
         };
-        await this.env.SYNC_METADATA.put(`sync-request:${request.id}`, JSON.stringify(request), { expirationTtl: 3600 });
+        if (this.env.ENABLE_WEBHOOK_LOGS === 'true') {
+          await this.env.SYNC_METADATA.put(`sync-request:${request.id}`, JSON.stringify(request), { expirationTtl: 300 });
+        }
       }
       return { success: true };
     } catch (e) {


### PR DESCRIPTION
## Summary
- Aggregate metrics per day and summarize without scanning all keys
- Cache mapping counts and migration info in batch state so `/sync/status` uses a single KV read
- Make webhook logging optional and lighten rate-limiting writes with in-memory cache

## Testing
- `npm test` *(fails: ENETUNREACH errors and test timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_68a77c5830348327b4131e58e7b8db7a